### PR TITLE
Send transaction - fixes

### DIFF
--- a/dapp/config.js
+++ b/dapp/config.js
@@ -148,6 +148,7 @@ var txDefault = {
       managementPage: "https://testalerts.gnosis.pm/api/alert/manage/?code={auth-code}"
     }
   },
+  etherscanApiKey: '5HX5Z25IG7PGQ7BGCY3DTJ11MS2VE4Y1MK',
   walletFactoryAddresses: {
     'mainnet': {
       name: 'Mainnet',

--- a/dapp/controllers/sendTransactionCtrl.js
+++ b/dapp/controllers/sendTransactionCtrl.js
@@ -2,7 +2,7 @@
   function () {
     angular
     .module("multiSigWeb")
-    .controller("sendTransactionCtrl", function ($scope, $http, Wallet, Utils, Transaction, $uibModalInstance, ABI, Web3Service) {
+    .controller("sendTransactionCtrl", function ($scope, $http, Config, Wallet, Utils, Transaction, $uibModalInstance, ABI, Web3Service) {
       $scope.methods = [];
       $scope.tx = {
         value: 0

--- a/dapp/controllers/sendTransactionCtrl.js
+++ b/dapp/controllers/sendTransactionCtrl.js
@@ -2,7 +2,7 @@
   function () {
     angular
     .module("multiSigWeb")
-    .controller("sendTransactionCtrl", function ($scope, Wallet, Utils, Transaction, $uibModalInstance, ABI, Web3Service) {
+    .controller("sendTransactionCtrl", function ($scope, $http, Wallet, Utils, Transaction, $uibModalInstance, ABI, Web3Service) {
       $scope.methods = [];
       $scope.tx = {
         value: 0

--- a/dapp/controllers/sendTransactionCtrl.js
+++ b/dapp/controllers/sendTransactionCtrl.js
@@ -14,6 +14,12 @@
         Object.assign(tx, $scope.tx);
         var params = [];
         Object.assign(params, $scope.params);
+        if ($scope.method.inputs && $scope.method.inputs.length) {
+          // assign default value (otherwise transaction will fail when any value is not filled)
+          for (var i = 0; i < $scope.method.inputs.length; i++) {
+            params[i] = params[i] || ""
+          }
+        }
         if ($scope.method) {
           params.map(function(param, index) {
             // Parse if array param

--- a/dapp/controllers/sendTransactionCtrl.js
+++ b/dapp/controllers/sendTransactionCtrl.js
@@ -180,6 +180,23 @@
             $scope.abi = JSON.stringify($scope.abis[to].abi);
             $scope.name = $scope.abis[to].name;
             $scope.updateMethods();
+          } else {
+            // try to fetch from etherscan
+            Transaction.getEthereumChain().then(
+              function (data) {
+                var config = Config.getUserConfiguration()
+                var etherscanApiKey = config.etherscanApiKey
+                var etherscanApiBaseUrl = data.etherscanApi
+                $http.get(etherscanApiBaseUrl + '/api?module=contract&action=getabi&address=' + to + '&apikey=' + etherscanApiKey)
+                  .then(function (response) {
+                    if (response.data.message === 'OK') {
+                      $scope.abi = response.data.result
+                      $scope.updateMethods();
+                      // save for next time
+                      ABI.update($scope.abiArray, to, $scope.name)
+                    }
+                  })
+              })
           }
         }
       };

--- a/dapp/services/Transaction.js
+++ b/dapp/services/Transaction.js
@@ -305,6 +305,7 @@
                 else if (block && block.hash == "0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3") {
                   data.chain = "mainnet";
                   data.etherscan = "https://etherscan.io";
+                  data.etherscanApi = "https://api.etherscan.io";
                   data.walletFactoryAddress = "0xed5a90efa30637606ddaf4f4b3d42bb49d79bd4e";
                 }
                 else if (block && block.hash == "0x41941023680923e0fe4d74a34bdac8141f2540e3ae90623718e47d66d1ca4a2d") {
@@ -322,6 +323,8 @@
                   data.etherscan = "https://testnet.etherscan.io";
                   data.walletFactoryAddress = "0xd79426bcee5b46fde413ededeb38364b3e666097";
                 }
+
+                data.etherscanApi = data.etherscanApi || data.etherscan
 
                 resolve(data);
               });


### PR DESCRIPTION
- Dynamically load contract's ABI from etherscan if available (and save for later)
- Fix issue where "Send transaction" fails when one or more parameters aren't filled
  (e.g. `submitTransaction` will fail when only the value field is filled, but not data).