### PR TITLE
Decode multisig transactions

### DIFF
--- a/dapp/controllers/walletDetailCtrl.js
+++ b/dapp/controllers/walletDetailCtrl.js
@@ -343,7 +343,6 @@
                         $scope.transactions[tx].dataDecoded = $scope.getParam($scope.transactions[tx]);
                         if ($scope.transactions[tx].dataDecoded.notDecoded) {
                           // Try fetching from etherscan
-                          console.log('trying to fetch from ETHERSCAN: ', info.to)
                           Transaction.getEthereumChain().then(
                             function (data) {
                               var config = Config.getUserConfiguration()

--- a/dapp/controllers/walletDetailCtrl.js
+++ b/dapp/controllers/walletDetailCtrl.js
@@ -2,7 +2,7 @@
   function () {
     angular
     .module("multiSigWeb")
-    .controller("walletDetailCtrl", function (Web3Service, $scope, $filter, $sce, Wallet, $routeParams, Utils, Transaction, $interval, $uibModal, Token, ABI) {
+    .controller("walletDetailCtrl", function (Web3Service, $scope, $filter, $sce, Wallet, $routeParams, Utils, Transaction, $interval, $uibModal, Token, ABI, Config, $http) {
       $scope.wallet = {};
 
       $scope.$watch(
@@ -341,6 +341,26 @@
                       // Get data info if data has not being decoded, because is a new transactions or we don't have the abi to do it
                       if (!$scope.transactions[tx].dataDecoded || $scope.transactions[tx].dataDecoded.notDecoded || ($scope.transactions[tx].dataDecoded.usedABI && (!savedABI || savedABI.abi ))) {
                         $scope.transactions[tx].dataDecoded = $scope.getParam($scope.transactions[tx]);
+                        if ($scope.transactions[tx].dataDecoded.notDecoded) {
+                          // Try fetching from etherscan
+                          console.log('trying to fetch from ETHERSCAN: ', info.to)
+                          Transaction.getEthereumChain().then(
+                            function (data) {
+                              var config = Config.getUserConfiguration()
+                              var etherscanApiKey = config.etherscanApiKey
+                              var etherscanApiBaseUrl = data.etherscanApi
+                              $http.get(etherscanApiBaseUrl + '/api?module=contract&action=getabi&address=' + info.to + '&apikey=' + etherscanApiKey)
+                                .then(function (response) {
+                                  if (response.data.message === 'OK') {
+                                    // save in local storage
+                                    var abiArray = JSON.parse(response.data.result)
+                                    ABI.update(abiArray, info.to)
+                                    // update table
+                                    $scope.transactions[tx].dataDecoded = $scope.getParam($scope.transactions[tx]);
+                                  }
+                                })
+                            })
+                        }
                       }
                       // If destionation type has not been set
                       if (!$scope.transactions[tx].destination) {

--- a/dapp/controllers/walletTransactionCtrl.js
+++ b/dapp/controllers/walletTransactionCtrl.js
@@ -37,7 +37,7 @@
           $scope.method = $scope.methods[0];
           $scope.abiArray = JSON.parse($scope.abi);
           $scope.abiArray.map(function (item, index) {
-            if (!item.constant && item.name && item.type == "function") {
+            if (item.name && item.type == "function") {
               $scope.methods.push({name: item.name, index: index, inputs: item.inputs});
             }
           });

--- a/dapp/controllers/walletTransactionCtrl.js
+++ b/dapp/controllers/walletTransactionCtrl.js
@@ -6,7 +6,7 @@
   function () {
     angular
     .module("multiSigWeb")
-    .controller("walletTransactionCtrl", function (Web3Service, $scope, Wallet, Transaction, Utils, wallet, $uibModalInstance, ABI) {
+    .controller("walletTransactionCtrl", function (Web3Service, $scope, Wallet, Transaction, Utils, wallet, $uibModalInstance, ABI, Config, $http) {
 
       $scope.wallet = wallet;
       $scope.abiArray = null;
@@ -26,6 +26,23 @@
             $scope.abi = JSON.stringify($scope.abis[to].abi);
             $scope.name = $scope.abis[to].name;
             $scope.updateMethods();
+          } else {
+            // try to fetch from etherscan
+            Transaction.getEthereumChain().then(
+              function (data) {
+                var config = Config.getUserConfiguration()
+                var etherscanApiKey = config.etherscanApiKey
+                var etherscanApiBaseUrl = data.etherscanApi
+                $http.get(etherscanApiBaseUrl + '/api?module=contract&action=getabi&address=' + to + '&apikey=' + etherscanApiKey)
+                  .then(function (response) {
+                    if (response.data.message === 'OK') {
+                      $scope.abi = response.data.result
+                      $scope.updateMethods();
+                      // save for next time
+                      ABI.update($scope.abiArray, to, $scope.name)
+                    }
+                  })
+              })
           }
         }
       };

--- a/dapp/services/Wallet.js
+++ b/dapp/services/Wallet.js
@@ -24,7 +24,9 @@
         abiDecoder.addABI(abi);
       };
 
-      wallet.mergedABI = wallet.json.multiSigDailyLimit.abi.concat(wallet.json.multiSigDailyLimitFactory.abi).concat(wallet.json.token.abi);
+      wallet.mergedABI = Object.keys(wallet.json).map(key => wallet.json[key].abi).reduce((accAbiArray, currentAbiArray) => {
+        return accAbiArray.concat(currentAbiArray)
+      })
 
       // Concat cached abis
       var cachedABIs = ABI.get();


### PR DESCRIPTION
Following enhancements were implemented:
1. When reaching "Send multisig transaction" modal (Wallets -> Multisig Transactions -> Add):
   After initially filling destination address, if destination is a contract and its ABI not already loaded into local storage **there will be an attempt to fetch it from etherscan**.
2. In Multisig transactions "Data/Subject" column, the transaction data will be decoded according to:
   a. A pre-loaded ABI from `abi.js`.
   b. If a failed, ABI fetched from etherscan.